### PR TITLE
Making the dev webserv outside accessible

### DIFF
--- a/web/gulpfile.js
+++ b/web/gulpfile.js
@@ -85,6 +85,7 @@ gulp.task('connect', function() {
   connect.server({
     root: '.',
     port: 8000,
+    host: '0.0.0.0',
     livereload: true
   });
 });


### PR DESCRIPTION
Made dev webserver listen on '0.0.0.0' instead of localhost